### PR TITLE
Refactor RimNauts patch to work with newer version

### DIFF
--- a/1.4/_RimNauts/Patches/SpaceObjectsPatch.xml
+++ b/1.4/_RimNauts/Patches/SpaceObjectsPatch.xml
@@ -1,9 +1,0 @@
-
-<Patch>
-	<Operation Class = "PatchOperationAddModExtension">
-		<xpath>Defs/WorldObjectDef[defName = "HotMoon" or defName = "RockMoon" or defName = "GasMoon" or defName = "BrokenMoon" or defName = "AsteroidSatellite" or defName = "SatelliteCore"]</xpath>
-		<value>
-			<li Class = "Vehicles.SpaceObjectDefModExtension"/>
-		</value>
-	</Operation>
-</Patch>

--- a/1.4/_RimNauts2/Patches/SpaceObjectsPatch.xml
+++ b/1.4/_RimNauts2/Patches/SpaceObjectsPatch.xml
@@ -1,0 +1,16 @@
+
+<Patch>
+	<Operation Class = "PatchOperationAddModExtension">
+		<xpath>Defs/WorldObjectDef[defName = "RimNauts2_ObjectHolder"]</xpath>
+		<value>
+			<li Class = "Vehicles.SpaceObjectDefModExtension">
+				<!-- Land to Space -->
+				<fixedPercentCostL2S>0.8</fixedPercentCostL2S>
+				<!-- Space to Land -->
+				<fixedPercentCostS2L>0.15</fixedPercentCostS2L>
+				<!-- Space to Space -->
+				<multiplierCostS2S>0.1</multiplierCostS2S>
+			</li>
+		</value>
+	</Operation>
+</Patch>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -8,6 +8,6 @@
 		<li IfModActive = "Ludeon.RimWorld.Biotech">1.4/_Biotech</li>
 		
 		<li IfModActive = "kentington.saveourship2">1.4/_SaveOurShip2</li>
-		<li IfModActive = "RadZerp.neoRimNauts">1.4/_RimNauts</li>
+		<li IfModActive = "sindre0830.rimnauts2">1.4/_RimNauts2</li>
 	</v1.4>
 </loadFolders>


### PR DESCRIPTION
Updated the patch to work with RimNauts 2.

Still issues with the ```Vehicles.FlightNode.RecalculateCenter()``` not being called making the vehicle fly to the old location and not keep up with the real-time updates to ```RimWorld.Planet.WorldObject.DrawPos()```. There is also an issue with the vehicle teleporting to ```Verse.Find.WorldGrid.GetTileCenter()``` when it is finished with the ```FlightPath``` making it return to the planet. The patch I created for the ```Settle``` comp doesn't work here but it is something I would need to fix on my side.