### PR TITLE
HarmonyPatch fix for Roads Of The Rim

### DIFF
--- a/Source/Vehicles/Harmony/ConditionalPatches/Compatibility_RoadsOfTheRim.cs
+++ b/Source/Vehicles/Harmony/ConditionalPatches/Compatibility_RoadsOfTheRim.cs
@@ -20,7 +20,7 @@ namespace Vehicles
 
 		public override void PatchAll(ModMetaData mod, Harmony harmony)
 		{
-			Type alertClassType = AccessTools.TypeByName("RoadsOfTheRim.Patch_Alert_CaravanIdle_GetReport");
+			Type alertClassType = AccessTools.TypeByName("RoadsOfTheRim.HarmonyPatches.Patch_Alert_CaravanIdle_GetReport");
 			harmony.Patch(original: AccessTools.Method(alertClassType, "Postfix"),
 				transpiler: new HarmonyMethod(typeof(Compatibility_RoadsOfTheRim),
 				nameof(GetAlertReportIdleConstructionVehicle)));


### PR DESCRIPTION
Fix the Harmony Patch Problem when **Roads of the Rim** installed.

Logs:
```shell
[SmashTools] Failed to apply patch <color=#00A680FF>Vehicles.Compatibility_RoadsOfTheRim</color>. Exception=System.NullReferenceException: Null method for SmashPhil.SmashTools
[Ref D7468D25]
 at HarmonyLib.PatchProcessor.Patch () [0x0001d] in <abec11463bc04855a5322a0a868aeb22>:0 
 at HarmonyLib.Harmony.Patch (System.Reflection.MethodBase original, HarmonyLib.HarmonyMethod prefix, HarmonyLib.HarmonyMethod postfix, HarmonyLib.HarmonyMethod transpiler, HarmonyLib.HarmonyMethod finalizer) [0x0002a] in <abec11463bc04855a5322a0a868aeb22>:0 
 at Vehicles.Compatibility_RoadsOfTheRim.PatchAll (Verse.ModMetaData mod, HarmonyLib.Harmony harmony) [0x00031] in <abeefc5ed15c4050a1a329192d30af9a>:0 
 at <0x1cef55e1d60 + 0x0035f> <unknown method> 
```