### PR TITLE
"Transfer to vehicle" feature

### DIFF
--- a/Languages/English/Keyed/Labels.xml
+++ b/Languages/English/Keyed/Labels.xml
@@ -20,6 +20,11 @@
 	<VF_UndraftVehicleDesc>Undrafts vehicle, disabling the consumption of fuel and disallowing movement.</VF_UndraftVehicleDesc>
 	<VF_RefuelFromInventory>Refuel From Inventory</VF_RefuelFromInventory>
 	<VF_VehicleFuelCost>Fuel: {0}</VF_VehicleFuelCost>
+
+	<VF_TransferToVehicle_Order>Transfer to vehicle</VF_TransferToVehicle_Order>
+	<VF_TransferToVehicle_Order_Desc>Transfer selected thing(s) to the target vehicle's cargo.</VF_TransferToVehicle_Order_Desc>
+	<VF_TransferToVehicle_Cancel>Cancel transfer</VF_TransferToVehicle_Cancel>
+	<VF_TransferToVehicle_Cancel_Desc>Cancel transfer of selected thing(s) to any vehicle's cargo.</VF_TransferToVehicle_Cancel_Desc>
 	
 	<!-- UI / Buttons -->
 	<VF_ShowAllItemsOnMap>Show All Items On Map</VF_ShowAllItemsOnMap>

--- a/Source/Vehicles/Gizmo/Command_TransferToVehicle_Cancel.cs
+++ b/Source/Vehicles/Gizmo/Command_TransferToVehicle_Cancel.cs
@@ -1,0 +1,31 @@
+﻿using Verse;
+
+namespace Vehicles
+{
+	public class Command_TransferToVehicle_Cancel : Command_Action
+	{
+		public static Command_TransferToVehicle_Cancel Instance { get; }
+
+		private Command_TransferToVehicle_Cancel()
+		{
+			defaultLabel = "VF_TransferToVehicle_Cancel".Translate();
+			defaultDesc = "VF_TransferToVehicle_Cancel_Desc".Translate();
+			icon = VehicleTex.CancelPackCargoIcon[(uint)VehicleType.Land];
+			Order = 1001f;
+			action = Action;
+		}
+
+		static Command_TransferToVehicle_Cancel()
+		{
+			Instance = new Command_TransferToVehicle_Cancel();
+		}
+
+		private static void Action()
+		{
+			foreach (var thing in Command_TransferToVehicle_Order.GetSelectedTransferableThings())
+			{
+				thing.CancelTransferToAnyVehicle();
+			}
+		}
+	}
+}

--- a/Source/Vehicles/Gizmo/Command_TransferToVehicle_Order.cs
+++ b/Source/Vehicles/Gizmo/Command_TransferToVehicle_Order.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using RimWorld;
+using Verse;
+
+namespace Vehicles
+{
+	public class Command_TransferToVehicle_Order : Command_Target
+	{
+		public static Command_TransferToVehicle_Order Instance { get; }
+
+		private Command_TransferToVehicle_Order()
+		{
+			defaultLabel = "VF_TransferToVehicle_Order".Translate();
+			defaultDesc = "VF_TransferToVehicle_Order_Desc".Translate();
+			icon = VehicleTex.PackCargoIcon[(uint)VehicleType.Land];
+			Order = 1000f;
+			action = Action;
+			targetingParams = TargetingParameters.ForPawns();
+			targetingParams.validator = IsVehicle;
+		}
+
+		static Command_TransferToVehicle_Order()
+		{
+			Instance = new Command_TransferToVehicle_Order();
+		}
+
+		private static bool IsVehicle(TargetInfo target)
+		{
+			return target.Thing is VehiclePawn;
+		}
+
+		public static IEnumerable<Thing> GetSelectedTransferableThings()
+		{
+			foreach (var obj in Find.Selector.SelectedObjects)
+			{
+				if (obj is Thing thing && thing.CanBeTransferredToVehiclesCargo())
+				{
+					yield return thing;
+				}
+			}
+		}
+
+		private static void Action(LocalTargetInfo target)
+		{
+			if (target.Thing is VehiclePawn vehicle)
+			{
+				GetSelectedTransferableThings().TransferToVehicle(vehicle);
+			}
+		}
+	}
+}

--- a/Source/Vehicles/Harmony/PatchCategories/Gizmos.cs
+++ b/Source/Vehicles/Harmony/PatchCategories/Gizmos.cs
@@ -34,6 +34,9 @@ namespace Vehicles
 			VehicleHarmony.Patch(original: AccessTools.Method(typeof(BuildCopyCommandUtility), nameof(BuildCopyCommandUtility.BuildCopyCommand)),
 				prefix: new HarmonyMethod(typeof(Gizmos),
 				nameof(VehicleMaterialOnCopyBuildGizmo)));
+			VehicleHarmony.Patch(original: AccessTools.Method(typeof(Thing), nameof(Thing.GetGizmos)), prefix: null,
+				postfix: new HarmonyMethod(typeof(Gizmos),
+				nameof(ThingTransferToVehicleGizmo)));
 
 			VehicleHarmony.Patch(original: AccessTools.Method(typeof(Dialog_InfoCard), nameof(Dialog_InfoCard.DoWindowContents)),
 				prefix: new HarmonyMethod(typeof(Gizmos),
@@ -312,6 +315,26 @@ namespace Vehicles
 				return false;
 			}
 			return true;
+		}
+
+		public static IEnumerable<Gizmo> ThingTransferToVehicleGizmo(IEnumerable<Gizmo> __result, Thing __instance)
+		{
+			IEnumerator<Gizmo> enumerator = __result.GetEnumerator();
+
+			while (enumerator.MoveNext())
+			{
+				yield return enumerator.Current;
+			}
+
+			if (__instance.CanBeTransferredToVehiclesCargo())
+			{
+				yield return Command_TransferToVehicle_Order.Instance;
+
+				if (__instance.IsOrderedToBeTransferredToAnyVehicle())
+				{
+					yield return Command_TransferToVehicle_Cancel.Instance;
+				}
+			}
 		}
 	}
 }

--- a/Source/Vehicles/Utility/Extensions/Ext_Thing.cs
+++ b/Source/Vehicles/Utility/Extensions/Ext_Thing.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using SmashTools;
+using Verse;
+using Verse.AI;
+
+namespace Vehicles
+{
+	public static class Ext_Thing
+	{
+		public static bool CanBeTransferredToVehiclesCargo(this Thing thing)
+		{
+			return
+				thing.def.EverHaulable
+				||
+				(
+					thing is Pawn pawn
+					&&
+					pawn is VehiclePawn == false
+					&&
+					(
+						pawn.Faction?.IsPlayer == true
+						||
+						pawn.Downed
+					)
+				);
+		}
+
+		public static IEnumerable<VehiclePawn> GetVehiclesToBeTransferredTo(this Thing thing)
+		{
+			var map = thing.MapHeld;
+
+			if (map == null)
+			{
+				yield break;
+			}
+
+			var vehicles = map.GetCachedMapComponent<VehicleReservationManager>().VehicleListers(ReservationType.LoadVehicle);
+
+			foreach (var vehicle in vehicles)
+			{
+				if (vehicle.cargoToLoad?.FindTransferableFor(thing) != null)
+				{
+					yield return vehicle;
+				}
+			}
+		}
+
+		public static bool IsOrderedToBeTransferredToAnyVehicle(this Thing thing)
+		{
+			return thing.GetVehiclesToBeTransferredTo().Count() > 0;
+		}
+
+		public static void TransferToVehicle(this IEnumerable<Thing> things, VehiclePawn vehicle)
+		{
+			foreach (var thing in things)
+			{
+				thing.CancelTransferToAnyOtherVehicle(vehicle);
+				thing.TransferToVehicle(vehicle);
+			}
+
+			vehicle.MapHeld?.GetCachedMapComponent<VehicleReservationManager>().RegisterLister(vehicle, ReservationType.LoadVehicle);
+		}
+
+		public static void TransferToVehicle(this Thing thing, VehiclePawn vehicle)
+		{
+			(vehicle.cargoToLoad ??= new List<TransferableOneWay>()).AddThing(thing);
+		}
+
+		public static void CancelTransferToVehicle(this Thing thing, VehiclePawn vehicle)
+		{
+			if (vehicle.cargoToLoad?.RemoveThing(thing) == true)
+			{
+				thing.CancelRelatedJob(JobDefOf_Vehicles.LoadVehicle, JobCondition.QueuedNoLongerValid);
+			}
+		}
+
+		public static void CancelTransferToAnyOtherVehicle(this Thing thing, VehiclePawn vehicle)
+		{
+			foreach (var otherVehicle in thing.GetVehiclesToBeTransferredTo())
+			{
+				if (otherVehicle != vehicle)
+				{
+					thing.CancelTransferToVehicle(otherVehicle);
+				}
+			}
+		}
+
+		public static void CancelTransferToAnyVehicle(this Thing thing)
+		{
+			foreach (var vehicle in thing.GetVehiclesToBeTransferredTo())
+			{
+				thing.CancelTransferToVehicle(vehicle);
+			}
+		}
+
+		public static void CancelRelatedJob(this Thing thing, JobDef jobType, JobCondition cancelCondition)
+		{
+			var reservation = thing.MapHeld?.reservationManager.ReservationsReadOnly.FirstOrFallback(res => res?.Target.Thing == thing);
+
+			if (reservation?.Job.def == jobType)
+			{
+				reservation.Job.GetCachedDriver(reservation.Claimant).EndJobWith(cancelCondition);
+			}
+		}
+	}
+}

--- a/Source/Vehicles/Utility/Extensions/Ext_TransferableOneWay.cs
+++ b/Source/Vehicles/Utility/Extensions/Ext_TransferableOneWay.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using RimWorld;
+using Verse;
+
+namespace Vehicles
+{
+	public static class Ext_TransferableOneWay
+	{
+		public static void AddThing(this TransferableOneWay transferable, Thing thing)
+		{
+			if (transferable.things.Contains(thing) == false)
+			{
+				transferable.things.Add(thing);
+				transferable.AdjustTo(transferable.CountToTransfer + thing.stackCount);
+			}
+		}
+
+		public static bool RemoveThing(this TransferableOneWay transferable, Thing thing)
+		{
+			if (transferable.things.Remove(thing))
+			{
+				transferable.AdjustTo(transferable.CountToTransfer - thing.stackCount);
+
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void AddThing(this List<TransferableOneWay> transferables, Thing thing, TransferAsOneMode mode = TransferAsOneMode.PodsOrCaravanPacking)
+		{
+			var transferable = TransferableUtility.TransferableMatching(thing, transferables, mode);
+
+			if (transferable == null)
+			{
+				transferable = new TransferableOneWay();
+				transferables.Add(transferable);
+			}
+
+			transferable.AddThing(thing);
+		}
+
+		public static bool RemoveThing(this List<TransferableOneWay> transferables, Thing thing)
+		{
+			var transferable = transferables.FindTransferableFor(thing);
+
+			if (transferable?.RemoveThing(thing) == true)
+			{
+				if (transferable.HasAnyThing == false)
+				{
+					transferables.Remove(transferable);
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		// A more precise version of RimWorld.TransferableUtility.TransferableMatching.
+		public static TransferableOneWay FindTransferableFor(this List<TransferableOneWay> transferables, Thing thing)
+		{
+			return transferables.FirstOrFallback(transferable => transferable?.things.Contains(thing) == true);
+		}
+	}
+}

--- a/Source/Vehicles/Vehicles.csproj
+++ b/Source/Vehicles/Vehicles.csproj
@@ -167,6 +167,8 @@
     <Compile Include="CustomFeatures\Upgrades\UpgradeTextEntry.cs" />
     <Compile Include="CustomFeatures\Upgrades\UpgradeTreeDef.cs" />
     <Compile Include="CustomFeatures\Areas\Area_Road.cs" />
+    <Compile Include="Gizmo\Command_TransferToVehicle_Cancel.cs" />
+    <Compile Include="Gizmo\Command_TransferToVehicle_Order.cs" />
     <Compile Include="Gizmo\Command_Turret.cs" />
     <Compile Include="Gizmo\Designators\Designator_AreaRoadExpand.cs" />
     <Compile Include="Gizmo\Designators\Designator_AreaRoadClear.cs" />
@@ -478,6 +480,8 @@
     <Compile Include="Graphics\Misc\FloatMenuTargeter.cs" />
     <Compile Include="Graphics\Textures\TexData.cs" />
     <Compile Include="Graphics\VehicleGhostUtility.cs" />
+    <Compile Include="Utility\Extensions\Ext_Thing.cs" />
+    <Compile Include="Utility\Extensions\Ext_TransferableOneWay.cs" />
     <Compile Include="Utility\Extensions\Ext_Caravan.cs" />
     <Compile Include="Utility\Extensions\Ext_ThingOwner.cs" />
     <Compile Include="Utility\Extensions\Ext_Toils.cs" />


### PR DESCRIPTION
# Description

Adds 2 gizmos to (some) selected things.

# "Transfer to vehicle" gizmo

A gizmo for ordering the transfer of selected things to a vehicle's cargo.

## How to use

1. Select one or more things on a map.
2. If selected things can be transferred to a vehicle's cargo, a "Transfer to vehicle" gizmo will appear in the list of gizmos.
3. Click on a "Transfer to vehicle" gizmo.
4. Click on a vehicle.
5. Any valid selected things will be added to the vehicle's cargo list and pawns should start loading the vehicle.
 5.1. If a thing(s) is already ordered to be trasferred to another vehicle, it will be removed from that vehicle's cargo list and instead ordered to be transferred to the target vehicle.

As of right now a thing is considered valid for loading into a vehicle's cargo if it satisfies the following criteria:
- It is haulable.
- Or it is a pawn that belongs to the player's faction (they will be loaded into the vehicle's cargo, not on passenger seats).
- Or it is an incapacitated pawn, regardless of what faction it belongs to (if any).

# "Cancel transfer" gizmo

A gizmo for cancelling an order to transfer selected things to any vehicle's cargo.

## How to use

1. Select one or more things on a map.
2. If some of the selected things are ordered to be transferred to a vehicle, a "Cancel transfer" gizmo will appear in the list of gizmos.
3. Click on a "Cancel transfer" gizmo.
4. Selected things will be removed from any vehicle's cargo list and any related hauling jobs will be cancelled.

# Notes

There is a collision with functionality of already existing "Load pawn" gizmo. I personally find approach, implemented in this PR, more intuitive.