### PR TITLE
Extract cargo and passenger action boundaries

### DIFF
--- a/Source/Vehicles/Components/Vehicles/VehiclePawn/VehiclePawn_Rendering.cs
+++ b/Source/Vehicles/Components/Vehicles/VehiclePawn/VehiclePawn_Rendering.cs
@@ -578,7 +578,7 @@ public partial class VehiclePawn
         defaultLabel = "VF_LoadCargo".Translate(),
         icon = VehicleDef.LoadCargoIcon,
         hotKey = KeyBindingDefOf.Misc2,
-        action = delegate { Find.WindowStack.Add(new Dialog_LoadCargo(this)); }
+        action = OpenLoadCargoDialog
       };
       if (upgrading)
       {
@@ -931,6 +931,11 @@ public partial class VehiclePawn
         }
       }
     }
+  }
+
+  private void OpenLoadCargoDialog()
+  {
+    Find.WindowStack.Add(new Dialog_LoadCargo(this));
   }
 
   public override IEnumerable<FloatMenuOption> GetFloatMenuOptions(Pawn selPawn)

--- a/Source/Vehicles/Graphics/Dialogs/Dialog_LoadCargo.cs
+++ b/Source/Vehicles/Graphics/Dialogs/Dialog_LoadCargo.cs
@@ -114,19 +114,15 @@ namespace Vehicles
 			Rect rect2 = new Rect(rect.width / 2f - BottomButtonSize.x / 2f, rect.height - 55f - 17f, BottomButtonSize.x, BottomButtonSize.y);
 			if (Widgets.ButtonText(rect2, "AcceptButton".Translate(), true, true, true))
 			{
-				List<TransferableOneWay> cargoToTransfer = transferables.Where(t => t.CountToTransfer > 0).ToList();
-				vehicle.cargoToLoad = cargoToTransfer;
-				vehicle.Map.GetCachedMapComponent<VehicleReservationManager>().RegisterLister(vehicle, ReservationType.LoadVehicle);
-				Close(true);
+				Accept();
 			}
 			if (Widgets.ButtonText(new Rect(rect2.x - 10f - BottomButtonSize.x, rect2.y, BottomButtonSize.x, BottomButtonSize.y), "ResetButton".Translate(), true, true, true))
 			{
-				SoundDefOf.Tick_Low.PlayOneShotOnCamera(null);
-				CalculateAndRecacheTransferables();
+				Reset();
 			}
 			if (Widgets.ButtonText(new Rect(rect2.xMax + 10f, rect2.y, BottomButtonSize.x, BottomButtonSize.y), "CancelButton".Translate(), true, true, true))
 			{
-				Close(true);
+				Cancel();
 			}
 			if (Prefs.DevMode)
 			{
@@ -134,22 +130,7 @@ namespace Vehicles
 				float num = BottomButtonSize.y / 2f;
 				if (Widgets.ButtonText(new Rect(0f, rect.height - 55f - 17f, width, num), "Dev: Pack Instantly", true, true, true))
 				{
-					SoundDefOf.Tick_High.PlayOneShotOnCamera(null);
-					for(int i = 0; i < transferables.Count; i++)
-					{
-						List<Thing> things = transferables[i].things;
-						int countToTransfer = transferables[i].CountToTransfer;
-						Action<Thing, IThingHolder> transferred = null;
-						if(transferred is null)
-						{
-							transferred = delegate(Thing thing, IThingHolder originalHolder)
-							{
-								vehicle.AddOrTransfer(thing);
-							};
-						}
-						TransferableUtility.Transfer(things, countToTransfer, transferred);
-					}
-					Close(false);
+					PackInstantly();
 				}
 				if (Widgets.ButtonText(new Rect(0f, rect.height - 55f - 17f + num, width, num), "Dev: Select everything", true, true, true))
 				{
@@ -157,6 +138,38 @@ namespace Vehicles
 					SetToSendEverything();
 				}
 			}
+		}
+
+		private void Accept()
+		{
+			List<TransferableOneWay> cargoToTransfer = transferables.Where(t => t.CountToTransfer > 0).ToList();
+			vehicle.cargoToLoad = cargoToTransfer;
+			vehicle.Map.GetCachedMapComponent<VehicleReservationManager>().RegisterLister(vehicle, ReservationType.LoadVehicle);
+			Close(true);
+		}
+
+		private void Reset()
+		{
+			SoundDefOf.Tick_Low.PlayOneShotOnCamera(null);
+			CalculateAndRecacheTransferables();
+		}
+
+		private void Cancel()
+		{
+			Close(true);
+		}
+
+		private void PackInstantly()
+		{
+			SoundDefOf.Tick_High.PlayOneShotOnCamera(null);
+			for (int i = 0; i < transferables.Count; i++)
+			{
+				List<Thing> things = transferables[i].things;
+				int countToTransfer = transferables[i].CountToTransfer;
+				TransferableUtility.Transfer(things, countToTransfer,
+					(thing, _) => vehicle.AddOrTransfer(thing));
+			}
+			Close(false);
 		}
 
 		public void DrawCargoNumbers(Rect rect)

--- a/Source/Vehicles/Utility/Helpers/VehicleTabHelper_Passenger.cs
+++ b/Source/Vehicles/Utility/Helpers/VehicleTabHelper_Passenger.cs
@@ -276,62 +276,7 @@ public static class VehicleTabHelper_Passenger
     }
     try
     {
-      if (transferToHolder is VehicleRoleHandler { AreSlotsAvailable: false } transferToHandler)
-      {
-        if (hoveringOverPawn != null &&
-          draggedPawn.ParentHolder is VehicleRoleHandler curHandler &&
-          curHandler != transferToHolder && transferToHandler.CanOperateRole(draggedPawn) &&
-          curHandler.CanOperateRole(hoveringOverPawn))
-        {
-          curHandler.thingOwner.Swap(transferToHandler.thingOwner, draggedPawn,
-            hoveringOverPawn);
-          SoundDefOf.Click.PlayOneShotOnCamera();
-          transferToHandler.vehicle.EventRegistry[VehicleEventDefOf.PawnChangedSeats].ExecuteEvents();
-        }
-        else
-        {
-          Messages.Message("VF_HandlerNotEnoughRoom".Translate(draggedPawn, transferToHandler.role.label),
-            MessageTypeDefOf.RejectInput);
-        }
-      }
-      else if (draggedPawn.ParentHolder != transferToHolder)
-      {
-        switch (transferToHolder)
-        {
-          case VehicleRoleHandler targetHandler:
-            if (!targetHandler.CanOperateRole(draggedPawn))
-            {
-              bool canAssign = (targetHandler.role.HandlingTypes & HandlingType.Movement) == 0;
-              MessageTypeDef msgTypeDef = canAssign ?
-                MessageTypeDefOf.CautionInput :
-                MessageTypeDefOf.RejectInput;
-              Messages.Message("VF_IncapableStatusForRole".Translate(draggedPawn.LabelShortCap), msgTypeDef);
-
-              if (!canAssign)
-                return;
-            }
-            break;
-          case Pawn_InventoryTracker:
-            if (!draggedPawn.ShouldAlwaysTransferToVehiclesCargo())
-            {
-              Messages.Message("VF_CannotAddToCargo".Translate(draggedPawn.LabelShortCap),
-                MessageTypeDefOf.RejectInput);
-              return;
-            }
-            break;
-        }
-
-        IThingHolder previousHolder = draggedPawn.ParentHolder;
-        if (!transferToHolder.GetDirectlyHeldThings()
-         .TryAddOrTransfer(draggedPawn, canMergeWithExistingStacks: false))
-        {
-          Log.Warning($"Unable to add {draggedPawn} to {transferToHolder}.");
-          return;
-        }
-        SoundDefOf.Click.PlayOneShotOnCamera();
-        OnPawnChangedSeats(previousHolder);
-        draggedPawn.GetVehicleCaravan()?.RecacheVehicles();
-      }
+      TransferPawn(draggedPawn, hoveringOverPawn, transferToHolder);
     }
     finally
     {
@@ -339,17 +284,80 @@ public static class VehicleTabHelper_Passenger
     }
   }
 
-  private static void OnPawnChangedSeats(IThingHolder previousHolder)
+  private static void TransferPawn(Pawn pawn, Pawn hoveredPawn, IThingHolder targetHolder)
+  {
+    if (pawn == null || targetHolder == null)
+      return;
+
+    if (targetHolder is VehicleRoleHandler { AreSlotsAvailable: false } transferToHandler)
+    {
+      if (hoveredPawn != null &&
+        pawn.ParentHolder is VehicleRoleHandler curHandler &&
+        curHandler != targetHolder && transferToHandler.CanOperateRole(pawn) &&
+        curHandler.CanOperateRole(hoveredPawn))
+      {
+        curHandler.thingOwner.Swap(transferToHandler.thingOwner, pawn, hoveredPawn);
+        SoundDefOf.Click.PlayOneShotOnCamera();
+        transferToHandler.vehicle.EventRegistry[VehicleEventDefOf.PawnChangedSeats].ExecuteEvents();
+      }
+      else
+      {
+        Messages.Message("VF_HandlerNotEnoughRoom".Translate(pawn, transferToHandler.role.label),
+          MessageTypeDefOf.RejectInput);
+      }
+    }
+    else if (pawn.ParentHolder != targetHolder)
+    {
+      switch (targetHolder)
+      {
+        case VehicleRoleHandler targetHandler:
+          if (!targetHandler.CanOperateRole(pawn))
+          {
+            bool canAssign = (targetHandler.role.HandlingTypes & HandlingType.Movement) == 0;
+            MessageTypeDef msgTypeDef = canAssign ?
+              MessageTypeDefOf.CautionInput :
+              MessageTypeDefOf.RejectInput;
+            Messages.Message("VF_IncapableStatusForRole".Translate(pawn.LabelShortCap), msgTypeDef);
+
+            if (!canAssign)
+              return;
+          }
+          break;
+        case Pawn_InventoryTracker:
+          if (!pawn.ShouldAlwaysTransferToVehiclesCargo())
+          {
+            Messages.Message("VF_CannotAddToCargo".Translate(pawn.LabelShortCap),
+              MessageTypeDefOf.RejectInput);
+            return;
+          }
+          break;
+      }
+
+      IThingHolder previousHolder = pawn.ParentHolder;
+      if (!targetHolder.GetDirectlyHeldThings()
+       .TryAddOrTransfer(pawn, canMergeWithExistingStacks: false))
+      {
+        Log.Warning($"Unable to add {pawn} to {targetHolder}.");
+        return;
+      }
+      SoundDefOf.Click.PlayOneShotOnCamera();
+      OnPawnChangedSeats(pawn, previousHolder, targetHolder);
+      pawn.GetVehicleCaravan()?.RecacheVehicles();
+    }
+  }
+
+  private static void OnPawnChangedSeats(Pawn pawn, IThingHolder previousHolder,
+    IThingHolder targetHolder)
   {
     VehiclePawn fromVehicle = GetVehicle(previousHolder);
-    VehiclePawn toVehicle = GetVehicle(transferToHolder);
+    VehiclePawn toVehicle = GetVehicle(targetHolder);
 
     pawnSeatChanged = true;
     if (fromVehicle != null && toVehicle == null)
     {
-      if (!draggedPawn.Spawned && !draggedPawn.IsWorldPawn())
+      if (!pawn.Spawned && !pawn.IsWorldPawn())
       {
-        Find.WorldPawns.PassToWorld(draggedPawn);
+        Find.WorldPawns.PassToWorld(pawn);
       }
       fromVehicle.EventRegistry[VehicleEventDefOf.PawnExited].ExecuteEvents();
     }
@@ -361,9 +369,9 @@ public static class VehicleTabHelper_Passenger
       }
       else
       {
-        if (!draggedPawn.Spawned && draggedPawn.IsWorldPawn())
+        if (!pawn.Spawned && pawn.IsWorldPawn())
         {
-          Find.WorldPawns.RemovePawn(draggedPawn);
+          Find.WorldPawns.RemovePawn(pawn);
         }
         fromVehicle?.EventRegistry[VehicleEventDefOf.PawnExited].ExecuteEvents();
         toVehicle.EventRegistry[VehicleEventDefOf.PawnEntered].ExecuteEvents();


### PR DESCRIPTION
## Summary
- refactor cargo and passenger action boundaries for Multiplayer compatibility
- extract stable named private actions for the vehicle cargo dialog and passenger transfers
- preserve the existing UI behavior without expanding Vehicle Framework's public API

## Root cause
Cargo and passenger mutations were embedded in UI delegates or depended on static drag fields. External integrations therefore had to identify compiler-generated callbacks or reconstruct state that Vehicle Framework already owns.

## Approach
- route the load-cargo gizmo through a named private `VehiclePawn.OpenLoadCargoDialog` boundary
- extract `Accept`, `Reset`, `Cancel`, `PackInstantly`, and `SetToSendEverything` as private `Dialog_LoadCargo` actions
- route passenger drag completion through a named private `VehicleTabHelper_Passenger.TransferPawn` action and pass the pawn/holders explicitly through the seat-change bookkeeping

The original UI paths still call these methods. Multiplayer compatibility can bind the private methods through its publicized `Source_Referenced` assembly without making them supported public Vehicle Framework APIs.

## Test plan
- [x] Release build succeeds with no warnings or errors
- [x] Release build succeeds after keeping the extracted boundaries private
- [x] Rebuild Vanilla Vehicles Expanded against this exact Vehicle Framework build
- [x] Manual single-player: open the cargo dialog; exercise Reset, Cancel, Accept, cancel-loading, select-everything, and instant packing
- [x] Manual single-player: transfer passengers between compatible handlers, swap occupied handlers, and verify rejection paths leave assignments unchanged
- [x] Manual single-player: save/reload after cargo and passenger changes and verify holders/counts remain correct
