### PR TITLE
Expose named turret targeting actions

### DIFF
--- a/Source/Vehicles/Gizmo/Command_CooldownAction.cs
+++ b/Source/Vehicles/Gizmo/Command_CooldownAction.cs
@@ -49,6 +49,11 @@ public class Command_CooldownAction : Command_Turret
     }
   }
 
+  public void HaltTurret()
+  {
+    turret.SetTarget(LocalTargetInfo.Invalid);
+  }
+
   public override GizmoResult GizmoOnGUI(Vector2 topLeft, float maxWidth, GizmoRenderParms parms)
   {
     // We need to do a lazy init since turret field is populated by object initializer
@@ -142,7 +147,7 @@ public class Command_CooldownAction : Command_Turret
         }
         return new GizmoResult(GizmoState.Mouseover);
       }
-      turret.SetTarget(LocalTargetInfo.Invalid);
+      HaltTurret();
       return new GizmoResult(GizmoState.Clear);
     }
 

--- a/Source/Vehicles/Gizmo/Command_TargeterCooldownAction.cs
+++ b/Source/Vehicles/Gizmo/Command_TargeterCooldownAction.cs
@@ -17,12 +17,14 @@ public class Command_TargeterCooldownAction : Command_CooldownAction
   {
     if (turret.ReloadTicks <= 0)
     {
-      turret.SetTarget(LocalTargetInfo.Invalid);
-      TurretTargeter.BeginTargeting(targetingParams, delegate(LocalTargetInfo target)
-      {
-        turret.SetTarget(target);
-        turret.ResetPrefireTimer();
-      }, turret);
+      HaltTurret();
+      TurretTargeter.BeginTargeting(targetingParams, CommitTarget, turret);
     }
+  }
+
+  public void CommitTarget(LocalTargetInfo target)
+  {
+    turret.SetTarget(target);
+    turret.ResetPrefireTimer();
   }
 }


### PR DESCRIPTION
## Summary
- Refactor turret target cancellation and target commitment into named `HaltTurret` and `CommitTarget` methods.
- Preserve the existing gizmo behavior while exposing stable action boundaries for Multiplayer compatibility.

## Motivation
The turret gizmo currently performs these state changes through inline UI logic and an anonymous targeting callback. Multiplayer compatibility therefore has to intercept lower-level UI or closure machinery to synchronize the actions. Named methods let the compatibility patch register the intended actions directly and remove brittle callback/transpiler handling.

## Test plan
- [x] Vehicle Framework Release build succeeds with no warnings or errors.
- [x] Vanilla Vehicles Expanded rebuilds against the PR assemblies.
- [x] Manual target commit: selecting a valid cell commits the target and starts the prefire timer without consuming ammunition.
- [x] Manual target cancel: cancelling the targeter leaves the turret idle and preserves ammunition/reload state.
- [x] Manual halt: halting an active target clears it and it remains cleared after subsequent ticks.
- [x] Deployed build manually smoke-tested in game.