### PR TITLE
Extract vehicle caravan action boundaries

### DIFF
--- a/Source/Vehicles/Harmony/Patches/Patch_FormCaravanDialog.cs
+++ b/Source/Vehicles/Harmony/Patches/Patch_FormCaravanDialog.cs
@@ -144,6 +144,11 @@ internal class Patch_FormCaravanDialog : IPatchCategory
       original: AccessTools.Method(typeof(Dialog_FormCaravan), "DoBottomButtons"),
       transpiler: new HarmonyMethod(typeof(Patch_FormCaravanDialog),
         nameof(StartRoutePlanningForVehiclesTranspiler)));
+    HarmonyPatcher.Patch(
+      original: AccessTools.Method(typeof(Dialog_FormCaravan),
+        nameof(Dialog_FormCaravan.Notify_ChoseRoute)),
+      transpiler: new HarmonyMethod(typeof(Patch_FormCaravanDialog),
+        nameof(ChooseVehicleStartingTileTranspiler)));
     HarmonyPatcher.Patch(original: AccessTools.Method(typeof(Dialog_FormCaravan), "TrySend"),
       prefix: new HarmonyMethod(typeof(Patch_FormCaravanDialog),
         nameof(TryAndSendWithVehicles)));
@@ -622,9 +627,6 @@ internal class Patch_FormCaravanDialog : IPatchCategory
     MethodInfo startPlanningMethod =
       AccessTools.Method(typeof(WorldRoutePlanner), nameof(WorldRoutePlanner.Start),
         parameters: [typeof(Dialog_FormCaravan)]);
-    FieldInfo mapField = AccessTools.Field(typeof(Dialog_FormCaravan), "map");
-    FieldInfo autoSelectTravelSuppliesField =
-      AccessTools.Field(typeof(Dialog_FormCaravan), "autoSelectTravelSupplies");
     for (int i = 0; i < instructionList.Count; i++)
     {
       CodeInstruction instruction = instructionList[i];
@@ -634,13 +636,6 @@ internal class Patch_FormCaravanDialog : IPatchCategory
         // Callvirt WorldRoutePlanner::Start(Dialog_FormCaravan)
         instruction = instructionList[++i];
         // ON STACK - WorldRoutePlanner instance, Dialog_FormCaravan instance
-        // this.map
-        yield return new CodeInstruction(opcode: OpCodes.Ldarg_0);
-        yield return new CodeInstruction(opcode: OpCodes.Ldfld, operand: mapField);
-        // this.autoSelectTravelSupplies
-        yield return new CodeInstruction(opcode: OpCodes.Ldarg_0);
-        yield return new CodeInstruction(opcode: OpCodes.Ldfld,
-          operand: autoSelectTravelSuppliesField);
         yield return new CodeInstruction(opcode: OpCodes.Call,
           operand: AccessTools.Method(typeof(Patch_FormCaravanDialog),
             nameof(WorldRoutePannerReroute)));
@@ -651,7 +646,7 @@ internal class Patch_FormCaravanDialog : IPatchCategory
 
   // NOTE - It's easier to pass in the world route planner since it's already on the stack
   private static void WorldRoutePannerReroute(WorldRoutePlanner routePlanner,
-    Dialog_FormCaravan formCaravan, Map map, bool autoSelectTravelSupplies)
+    Dialog_FormCaravan formCaravan)
   {
     if (VehiclesSelected(formCaravan.transferables))
     {
@@ -666,31 +661,44 @@ internal class Patch_FormCaravanDialog : IPatchCategory
       {
         Find.WindowStack.Add(formCaravan);
         formCaravan.Notify_NoLongerChoosingRoute();
-      }, ChoseVehicleRoute);
+      }, formCaravan.Notify_ChoseRoute);
     }
     else
     {
       routePlanner.Start(formCaravan);
     }
-    return;
+  }
 
-    void ChoseVehicleRoute(PlanetTile tile)
+  private static IEnumerable<CodeInstruction> ChooseVehicleStartingTileTranspiler(
+    IEnumerable<CodeInstruction> instructions)
+  {
+    MethodInfo bestExitTileMethod = AccessTools.Method(typeof(CaravanExitMapUtility),
+      nameof(CaravanExitMapUtility.BestExitTileToGoTo),
+      parameters: [typeof(PlanetTile), typeof(Map)]);
+    MethodInfo replacement = AccessTools.Method(typeof(Patch_FormCaravanDialog),
+      nameof(BestExitTileToGoTo));
+
+    foreach (CodeInstruction instruction in instructions)
     {
-      CaravanFormation.formation.DestinationTile = tile;
-      List<VehicleDef> vehicleDefs = TransferableUtility
-       .GetPawnsFromTransferables(formCaravan.transferables)
-       .UniqueVehicleDefsInList();
-      CaravanFormation.formation.StartingTile =
-        CaravanHelper.BestExitTileToGoTo(vehicleDefs, tile, map);
-      CaravanFormation.formation.TicksToArriveDirty = true;
-      CaravanFormation.formation.DaysWorthOfFoodDirty = true;
-
-      formCaravan.soundAppear.PlayOneShotOnCamera();
-      if (autoSelectTravelSupplies)
+      if (instruction.Calls(bestExitTileMethod))
       {
-        CaravanFormation.formation.SelectApproximateBestTravelSupplies();
+        yield return new CodeInstruction(OpCodes.Ldarg_0);
+        instruction.operand = replacement;
       }
+      yield return instruction;
     }
+  }
+
+  private static PlanetTile BestExitTileToGoTo(PlanetTile destinationTile, Map map,
+    Dialog_FormCaravan formCaravan)
+  {
+    if (!VehiclesSelected(formCaravan.transferables))
+      return CaravanExitMapUtility.BestExitTileToGoTo(destinationTile, map);
+
+    List<VehicleDef> vehicleDefs = TransferableUtility
+     .GetPawnsFromTransferables(formCaravan.transferables)
+     .UniqueVehicleDefsInList();
+    return CaravanHelper.BestExitTileToGoTo(vehicleDefs, destinationTile, map);
   }
 
   /// <summary>

--- a/Source/Vehicles/Utility/Helpers/World/CaravanFormation.cs
+++ b/Source/Vehicles/Utility/Helpers/World/CaravanFormation.cs
@@ -138,50 +138,50 @@ public static class CaravanFormation
       SoundDefOf.Tick_High.PlayOneShotOnCamera();
       formCaravan.Close(false);
     }
-    return;
+  }
 
-    bool TryFormAndSendCaravan()
+  private static bool TryFormAndSendCaravan()
+  {
+    Assert.IsNotNull(formation);
+    foreach (Pawn pawn in formation.pawns)
     {
-      foreach (Pawn pawn in formation.pawns)
+      if (pawn is VehiclePawn vehicle)
       {
-        if (pawn is VehiclePawn vehicle)
-        {
-          vehicle.DisembarkAll();
-        }
+        vehicle.DisembarkAll();
       }
-      if (!CheckForErrors())
-      {
-        return false;
-      }
-      Direction8Way direction8WayFromTo =
-        Find.WorldGrid.GetDirection8WayFromTo(formation.Dialog.CurrentTile, formation.StartingTile);
-      if (!TryFindExitSpot(formation.pawns, reachableForEveryColonist: true, out IntVec3 intVec))
-      {
-        if (!TryFindExitSpot(formation.pawns, reachableForEveryColonist: false, out intVec))
-        {
-          Messages.Message(
-            "CaravanCouldNotFindExitSpot".Translate(direction8WayFromTo.LabelShort()),
-            MessageTypeDefOf.RejectInput, false);
-          return false;
-        }
-        Messages.Message(
-          "CaravanCouldNotFindReachableExitSpot".Translate(direction8WayFromTo.LabelShort()),
-          new GlobalTargetInfo(intVec, formation.Map), MessageTypeDefOf.CautionInput, false);
-      }
-      if (!TryFindRandomPackingSpot(intVec, out IntVec3 meetingPoint))
-      {
-        Messages.Message(
-          "CaravanCouldNotFindPackingSpot".Translate(direction8WayFromTo.LabelShort()),
-          new GlobalTargetInfo(intVec, formation.Map), MessageTypeDefOf.RejectInput, false);
-        return false;
-      }
-      formation.RecacheTransferables();
-      VehicleCaravanFormingUtility.StartFormingCaravan(formation.Dialog.transferables,
-        meetingPoint, intVec, formation.StartingTile, formation.DestinationTile);
-      Messages.Message("CaravanFormationProcessStarted".Translate(), formation.vehicles[0],
-        MessageTypeDefOf.PositiveEvent, false);
-      return true;
     }
+    if (!CheckForErrors())
+    {
+      return false;
+    }
+    Direction8Way direction8WayFromTo =
+      Find.WorldGrid.GetDirection8WayFromTo(formation.Dialog.CurrentTile, formation.StartingTile);
+    if (!TryFindExitSpot(formation.pawns, reachableForEveryColonist: true, out IntVec3 intVec))
+    {
+      if (!TryFindExitSpot(formation.pawns, reachableForEveryColonist: false, out intVec))
+      {
+        Messages.Message(
+          "CaravanCouldNotFindExitSpot".Translate(direction8WayFromTo.LabelShort()),
+          MessageTypeDefOf.RejectInput, false);
+        return false;
+      }
+      Messages.Message(
+        "CaravanCouldNotFindReachableExitSpot".Translate(direction8WayFromTo.LabelShort()),
+        new GlobalTargetInfo(intVec, formation.Map), MessageTypeDefOf.CautionInput, false);
+    }
+    if (!TryFindRandomPackingSpot(intVec, out IntVec3 meetingPoint))
+    {
+      Messages.Message(
+        "CaravanCouldNotFindPackingSpot".Translate(direction8WayFromTo.LabelShort()),
+        new GlobalTargetInfo(intVec, formation.Map), MessageTypeDefOf.RejectInput, false);
+      return false;
+    }
+    formation.RecacheTransferables();
+    VehicleCaravanFormingUtility.StartFormingCaravan(formation.Dialog.transferables,
+      meetingPoint, intVec, formation.StartingTile, formation.DestinationTile);
+    Messages.Message("CaravanFormationProcessStarted".Translate(), formation.vehicles[0],
+      MessageTypeDefOf.PositiveEvent, false);
+    return true;
   }
 
   private static void ReformInstantly()


### PR DESCRIPTION
## Summary
- route vehicle caravan destinations through vanilla `Dialog_FormCaravan.Notify_ChoseRoute` while substituting the vehicle-specific exit tile
- lift the final vehicle-caravan send action into a named private method
- provide stable Harmony action boundaries for Multiplayer compatibility without expanding Vehicle Framework's public API

## Root cause
Vehicle Framework completed route selection in a custom callback that duplicated part of vanilla's state, estimate, sound, and automatic-supply transaction. Its final send action was also a local function. Multiplayer compatibility therefore had to target lower-level implementation details, and the copied route flow could drift from vanilla behavior.

## Approach
The vehicle route planner now returns through vanilla `Notify_ChoseRoute`. A narrow transpiler replaces only vanilla's exit-tile calculation, selecting `CaravanHelper.BestExitTileToGoTo` when vehicles are present and retaining the vanilla fallback otherwise. The existing final send body is lifted unchanged into the named private `CaravanFormation.TryFormAndSendCaravan` method. Multiplayer compatibility can bind that method through its publicized `Source_Referenced` assembly.

## Test plan
- [x] Vehicle Framework Release build succeeds with no warnings or errors
- [x] Release build succeeds after keeping the extracted boundary private
- [x] Vanilla Vehicles Expanded rebuilds against the branch assemblies
- [x] No-vehicle route selection retains vanilla exit selection, ETA, and automatic travel supplies
- [x] Vehicle route acceptance returns to the caravan dialog with valid estimates and automatic supplies
- [x] Direct vehicle send starts one forming lord with the selected vehicle, operator, and route intact across 120 ticks
- [x] Warning/confirmation send starts the same transaction exactly once and remains stable across 120 ticks
- [x] Manual deployment smoke-tested; the separately observed map-edge warning was isolated against the unmodified upstream base and is not introduced by this diff
