### PR TITLE
As deploy on landing is a QoL/convenience feature for player, it

### DIFF
--- a/Source/Vehicles/CustomFeatures/AerialVehicles/Skyfaller/VehicleSkyfaller_Arriving.cs
+++ b/Source/Vehicles/CustomFeatures/AerialVehicles/Skyfaller/VehicleSkyfaller_Arriving.cs
@@ -94,7 +94,7 @@ public class VehicleSkyfaller_Arriving : VehicleSkyfaller
     {
       GenSpawn.Spawn(vehicle, Position, Map, LandingRotation);
       vehicle.TryDamageObstructions();
-      if (VehicleMod.settings.main.deployOnLanding)
+      if (VehicleMod.settings.main.deployOnLanding || vehicle.Faction != Faction.OfPlayer)
       {
         vehicle.CompVehicleLauncher.SetTimedDeployment();
       }


### PR DESCRIPTION
shouldn't change non-player vehicle landing behavior. Fixed that.